### PR TITLE
Inform composer that the GMP extension is required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.4.0",
+        "ext-gmp": "*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Just noticed this wasn't specified while evaluating this library.
