### PR TITLE
hash codes compared with strtoupper()

### DIFF
--- a/src/BitcoinPHP/BitcoinECDSA/BitcoinECDSA.php
+++ b/src/BitcoinPHP/BitcoinECDSA/BitcoinECDSA.php
@@ -1127,7 +1127,7 @@ class BitcoinECDSA
         while(strlen($xRes) < 64)
             $xRes = '0' . $xRes;
 
-        if($xRes == $R)
+        if(strtoupper($xRes) == strtoupper($R))
             return true;
         else
             return false;


### PR DESCRIPTION
I had problems with verify message. I send hashcode in upper case and checkSignaturePoints function compare it with the same hashcode in lower case.
And if I send $hash in lower case to this function, then it dont't work too.