### PR TITLE
Fixed testnet WIF format bug

### DIFF
--- a/src/BitcoinPHP/BitcoinECDSA/BitcoinECDSA.php
+++ b/src/BitcoinPHP/BitcoinECDSA/BitcoinECDSA.php
@@ -77,6 +77,18 @@ class BitcoinECDSA
         return $this->networkPrefix;
     }
 
+    /**
+     * Returns the current network prefix for WIF, '80' = main network, 'ef' = test network.
+     *
+     * @return string (hexa)
+     */
+    public function getPrivatePrefix(){
+        if($this->networkPrefix =='6f')
+            return 'ef';
+        else
+           return '80';
+    }
+
     /***
      * Permutation table used for Base58 encoding and decoding.
      *
@@ -825,7 +837,7 @@ class BitcoinECDSA
         while(strlen($k) < 64)
             $k = '0' . $k;
         
-        $secretKey  = '80' . $k;
+        $secretKey  =  $this->getPrivatePrefix() . $k;
         
         if($compressed) {
             $secretKey .= '01';


### PR DESCRIPTION
Thank you for providing this **awesome bitcoin library** for PHP.
Unfortunately, I've occurred the WIF format bug when using **testnet network.**
This is due to the getWif($compressed) method doesn't judge the network.
I fixed this bug directly and it works now.

Here are what I've done. 
Cheers!