### PR TITLE
Tiny typo

### DIFF
--- a/src/BitcoinPHP/BitcoinECDSA/BitcoinECDSA.php
+++ b/src/BitcoinPHP/BitcoinECDSA/BitcoinECDSA.php
@@ -384,7 +384,7 @@ class BitcoinECDSA
                               $p
                       );
 
-        // nPtX = slope * (ptX1 - nPtX) - ptY1
+        // nPtY = slope * (ptX1 - nPtX) - ptY1
         $nPt['y']   = gmp_mod(
                               gmp_sub(
                                       gmp_mul(


### PR DESCRIPTION
Comment has `nPtX` instead of `nPtY`.